### PR TITLE
Replaced deprecated methods

### DIFF
--- a/text-tools.sketchplugin/Contents/Sketch/library.cocoascript
+++ b/text-tools.sketchplugin/Contents/Sketch/library.cocoascript
@@ -97,15 +97,15 @@ lib.createStyleFromDescription = function(description){
     var border = description.border;
 
     if(fill){
-        var styleFill        = style.fills().addNewStylePart();
-        var styleFillColor   = MSColor.colorWithSVGString(fill[0]);
+        var styleFill        = style.addStylePartOfType(0);
+        var styleFillColor   = MSColor.colorWithRed_green_blue_alpha(fill[0].r, fill[0].g, fill[0].b, fill[0].a);
         styleFillColor.alpha = fill[1] || 1.0;
         styleFill.color      = styleFillColor;
     }
 
     if(border){
-        var styleBorder        = style.borders().addNewStylePart();
-        var styleBorderColor   = MSColor.colorWithSVGString(border[0]);
+        var styleBorder        = style.addStylePartOfType(1);
+        var styleBorderColor   = MSColor.colorWithRed_green_blue_alpha(border[0].r, border[0].g, border[0].b, border[0].a);
         styleBorderColor.alpha = border[1] || 1.0;
         styleBorder.color      = styleBorderColor;
     }


### PR DESCRIPTION
fixes #1 

* `.addNewStylePart()` --> `.addStylePartOfType()`
* `.colorWithSVGString()` --> `.colorWithRed_green_blue_alpha()`

*Refs*
http://mail.sketchplugins.com/pipermail/dev_sketchplugins.com/2016-May/003781.html
https://github.com/keremciu/sketch-iconfont/commit/7e46eb4f5f7580640182e54a8fccc67c64b2e082

Fixes issue with 'Create Font Metrics'